### PR TITLE
Add standard POST redirect for non-AJAX requests

### DIFF
--- a/commerceregisteroncheckout/controllers/CommerceRegisterOnCheckoutController.php
+++ b/commerceregisteroncheckout/controllers/CommerceRegisterOnCheckoutController.php
@@ -51,6 +51,8 @@ class CommerceRegisterOnCheckoutController extends BaseController
         // Appropriate Ajax responses...
         if($ajax){
             $this->returnJson(["success"=>true]);
+        } else {
+            $this->redirectToPostedUrl();
         }
 
     }

--- a/commerceregisteroncheckout/controllers/CommerceRegisterOnCheckoutController.php
+++ b/commerceregisteroncheckout/controllers/CommerceRegisterOnCheckoutController.php
@@ -24,7 +24,8 @@ class CommerceRegisterOnCheckoutController extends BaseController
             if($ajax){
                 $this->returnErrorJson("Password cannot be empty");
             } else {
-                throw new HttpException(400, Craft::t("Password cannot be empty"));
+                craft()->userSession->setError(Craft::t('Password must be at least 6 characters in length'));
+                $this->redirect($url);
             }
         }
 


### PR DESCRIPTION
If the form submission is not handled via AJAX, then it seems to make sense to be able to handle a redirect if one is supplied in the POST data.