### PR TITLE
Clarify registered state

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,8 @@ Here's some sketch code to get you started:
 
     {# Get the results of user registration, if there are any... #}
     {% set registered = craft.commerceRegisterOnCheckout.checkoutRegistered ?? null %}
-    {% do craft.commerceRegisterOnCheckout.clearRegistered %}
     {% set account = craft.commerceRegisterOnCheckout.checkoutAccount ?? null %}
-    {% do craft.commerceRegisterOnCheckout.clearRegistered %}
+    {% do craft.commerceRegisterOnCheckout.clearRegisterSession %}
 
 
     {# Was registration attempted? #}

--- a/README.md
+++ b/README.md
@@ -106,11 +106,13 @@ Here's some sketch code to get you started:
 
     {# Get the results of user registration, if there are any... #}
     {% set registered = craft.commerceRegisterOnCheckout.checkoutRegistered ?? null %}
+    {% do craft.commerceRegisterOnCheckout.clearRegistered %}
     {% set account = craft.commerceRegisterOnCheckout.checkoutAccount ?? null %}
+    {% do craft.commerceRegisterOnCheckout.clearRegistered %}
 
 
     {# Was registration attempted? #}
-    {% if registered|length %}
+    {% if registered is not null %}
 
         {# Success, if true #}
         {% if registered %}
@@ -121,7 +123,7 @@ Here's some sketch code to get you started:
             {% if account|length %}
                 {% if "has already been taken" in account.getError('email') %}
 
-                ... Point ou they are already registered...
+                ... Point out they are already registered...
                 
             {% else %}
                 ...etc, e.g. present a user registration form with as much filled in as possible>

--- a/commerceregisteroncheckout/variables/CommerceRegisterOnCheckoutVariable.php
+++ b/commerceregisteroncheckout/variables/CommerceRegisterOnCheckoutVariable.php
@@ -40,7 +40,7 @@ class CommerceRegisterOnCheckoutVariable
         return $return;
     }
     
-    public function clearRegistered(){
+    public function clearRegisterSession(){
         craft()->httpSession->remove("registered");
         craft()->httpSession->remove("account");
     }

--- a/commerceregisteroncheckout/variables/CommerceRegisterOnCheckoutVariable.php
+++ b/commerceregisteroncheckout/variables/CommerceRegisterOnCheckoutVariable.php
@@ -20,16 +20,18 @@ class CommerceRegisterOnCheckoutVariable
      */
     public function checkoutRegistered(){
 
-        $return = "";
+        $return = null;
         
         $registered = craft()->httpSession->get("registered");
-        if($registered) $return = $registered;
-        
-        // For some reason these functions are called multiple times on the order complete template...
-        // So we can't remove them here.
-        //craft()->httpSession->remove("registered");
+        if(is_bool($registered)){
+            $return = $registered;
+        }
 
         return $return;
+    }
+    
+    public function clearRegistered(){
+        craft()->httpSession->remove("registered");
     }
 
     public function checkoutAccount(){

--- a/commerceregisteroncheckout/variables/CommerceRegisterOnCheckoutVariable.php
+++ b/commerceregisteroncheckout/variables/CommerceRegisterOnCheckoutVariable.php
@@ -29,10 +29,6 @@ class CommerceRegisterOnCheckoutVariable
 
         return $return;
     }
-    
-    public function clearRegistered(){
-        craft()->httpSession->remove("registered");
-    }
 
     public function checkoutAccount(){
 
@@ -41,11 +37,12 @@ class CommerceRegisterOnCheckoutVariable
         $account = craft()->httpSession->get("account");
         if($account) $return = $account;
 
-        // For some reason these functions are called multiple times on the order complete template...
-        // So we can't remove them here.        
-        //craft()->httpSession->remove("account");
-
         return $return;
+    }
+    
+    public function clearRegistered(){
+        craft()->httpSession->remove("registered");
+        craft()->httpSession->remove("account");
     }
 
 


### PR DESCRIPTION
Hey, thanks for all your work on this plugin! I noticed a couple things that weren't working great for me and tried adjusting a few things.

Currently Register On Checkout is returning an empty string for both failed registration attempts and orders where no registration was attempted. This can make it difficult at times to accurately display the correct results message.

The updated code searches for a boolean value and returns it if one is found, otherwise it returns null. Null allows for clearer comparison in twig since testing a variable's length or if it is null can produce the same result for a false boolean value and an empty string. This way, testing if `registered` is null will prevent any messages from displaying when no registration was attempted.

I also added the `clearRegisterSession` function which can be called by a twig `do` tag after the register status and account have been stored in variables. This way the result messages can be displayed after checkout, but the httpSession variables can be cleared manually so you don't have to wait for the user session to expire for the messages to stop displaying on future requests.

Let me know what you think!